### PR TITLE
Install instructions in multiple rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Only SVG-icons!
 ## Install
 Open Terminal and copy/paste commands:
 ```
-sudo apt-get install git
-cd /tmp; git clone https://github.com/varlesh/elementary-add.git; cd elementary-add; chmod +x install.sh; ./install.sh
+git clone https://github.com/varlesh/elementary-add.git
+cd elementary-add
+chmod +x install.sh
+./install.sh
 ```


### PR DESCRIPTION
I think that it would be more appropriate if we divide the installation instructions into multiple rows.

I also removed the first two lines because they're not necessary to anyone who knows around a Ubuntu-based operating system.

P.S. Consider adding a short description for your repository.
