### PR TITLE
Fix tray icons for chat apps

### DIFF
--- a/elementary-add-osx/status/22/tray-message.svg
+++ b/elementary-add-osx/status/22/tray-message.svg
@@ -1,0 +1,1 @@
+pidgin-tray-xa.svg

--- a/elementary-add-osx/status/22/tray-offline.svg
+++ b/elementary-add-osx/status/22/tray-offline.svg
@@ -1,0 +1,1 @@
+pidgin-tray-offline.svg

--- a/elementary-add-osx/status/22/tray-online.svg
+++ b/elementary-add-osx/status/22/tray-online.svg
@@ -1,0 +1,1 @@
+pidgin-tray-available.svg

--- a/elementary-add-osx/status/24/tray-message.svg
+++ b/elementary-add-osx/status/24/tray-message.svg
@@ -1,0 +1,1 @@
+pidgin-tray-xa.svg

--- a/elementary-add-osx/status/24/tray-offline.svg
+++ b/elementary-add-osx/status/24/tray-offline.svg
@@ -1,0 +1,1 @@
+pidgin-tray-offline.svg

--- a/elementary-add-osx/status/24/tray-online.svg
+++ b/elementary-add-osx/status/24/tray-online.svg
@@ -1,0 +1,1 @@
+pidgin-tray-available.svg

--- a/elementary-add/status/22/tray-message.svg
+++ b/elementary-add/status/22/tray-message.svg
@@ -1,0 +1,1 @@
+pidgin-tray-xa.svg

--- a/elementary-add/status/22/tray-offline.svg
+++ b/elementary-add/status/22/tray-offline.svg
@@ -1,0 +1,1 @@
+pidgin-tray-offline.svg

--- a/elementary-add/status/22/tray-online.svg
+++ b/elementary-add/status/22/tray-online.svg
@@ -1,0 +1,1 @@
+pidgin-tray-available.svg

--- a/elementary-add/status/24/tray-message.svg
+++ b/elementary-add/status/24/tray-message.svg
@@ -1,0 +1,1 @@
+pidgin-tray-xa.svg

--- a/elementary-add/status/24/tray-offline.svg
+++ b/elementary-add/status/24/tray-offline.svg
@@ -1,0 +1,1 @@
+pidgin-tray-offline.svg

--- a/elementary-add/status/24/tray-online.svg
+++ b/elementary-add/status/24/tray-online.svg
@@ -1,0 +1,1 @@
+pidgin-tray-available.svg


### PR DESCRIPTION
some chat apps like gajim use status/tray-\* as tray icons : map these to pidgin tray icons

Ref https://trac-plugins.gajim.org/wiki/AppindicatorSupportPlugin
